### PR TITLE
Add orb_slam3_msgs and SlamStatus

### DIFF
--- a/orb_slam3_bringup/CMakeLists.txt
+++ b/orb_slam3_bringup/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12.2)
 project(orb_slam3_bringup)
 
 find_package(ament_cmake REQUIRED)

--- a/orb_slam3_bringup/package.xml
+++ b/orb_slam3_bringup/package.xml
@@ -3,8 +3,8 @@
 <package format="3">
   <name>orb_slam3_bringup</name>
   <version>0.1.0</version>
-  <description>Mono ROS2 ORB_SLAM3 bringup</description>
-  <maintainer email="clyde@mcqueen.net">clyde</maintainer>
+  <description>ROS2 ORB_SLAM3 launch files</description>
+  <maintainer email="clyde@mcqueen.net">Clyde McQueen</maintainer>
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/orb_slam3_msgs/CMakeLists.txt
+++ b/orb_slam3_msgs/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.12.2)
+project(orb_slam3_msgs)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Debugging: set _dump_all_variables to true
+set(_dump_all_variables false)
+if(_dump_all_variables)
+  get_cmake_property(_variable_names VARIABLES)
+  list(SORT _variable_names)
+  foreach(_variable_name ${_variable_names})
+    message(STATUS "${_variable_name}=${${_variable_name}}")
+  endforeach()
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+# Generate ROS messages
+rosidl_generate_interfaces(
+  orb_slam3_msgs
+  msg/SlamStatus.msg
+  DEPENDENCIES geometry_msgs sensor_msgs std_msgs
+)
+
+ament_auto_package()

--- a/orb_slam3_msgs/msg/SlamStatus.msg
+++ b/orb_slam3_msgs/msg/SlamStatus.msg
@@ -1,0 +1,24 @@
+std_msgs/Header header
+
+# Tracking state
+int8 TRACKING_SYSTEM_NOT_READY = -1
+int8 TRACKING_NO_IMAGES_YET = 0
+int8 TRACKING_NOT_INITIALIZED = 1
+int8 TRACKING_OK = 2
+int8 TRACKING_RECENTLY_LOST = 3
+int8 TRACKING_LOST = 4
+int8 TRACKING_OK_KLT = 5
+
+int8 tracking_state
+
+# Map change, e.g., loop closure or bundle adjustment
+bool map_changed
+
+# Current map id
+uint32 map_id
+
+# Latest pose
+geometry_msgs/Pose pose
+
+# Tracked map points
+sensor_msgs/PointCloud2 tracked_points

--- a/orb_slam3_msgs/package.xml
+++ b/orb_slam3_msgs/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+    <name>orb_slam3_msgs</name>
+    <version>0.1.0</version>
+    <description>ROS2 ORB_SLAM3 messages</description>
+    <maintainer email="clyde@mcqueen.net">Clyde McQueen</maintainer>
+    <license>MIT</license>
+
+    <buildtool_depend>ament_cmake</buildtool_depend>
+
+    <build_depend>rosidl_default_generators</build_depend>
+
+    <exec_depend>rosidl_default_runtime</exec_depend>
+
+    <member_of_group>rosidl_interface_packages</member_of_group>
+
+    <depend>geometry_msgs</depend>
+    <depend>sensor_msgs</depend>
+    <depend>std_msgs</depend>
+
+    <export>
+        <build_type>ament_cmake</build_type>
+    </export>
+</package>

--- a/orb_slam3_ros/CMakeLists.txt
+++ b/orb_slam3_ros/CMakeLists.txt
@@ -29,7 +29,7 @@ find_package(orb_slam3_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
 # Debugging: set _dump_all_variables to true
-set(_dump_all_variables true)
+set(_dump_all_variables false)
 if(_dump_all_variables)
   get_cmake_property(_variable_names VARIABLES)
   list(SORT _variable_names)

--- a/orb_slam3_ros/CMakeLists.txt
+++ b/orb_slam3_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12.2)
 project(orb_slam3_ros)
 
 # Hack: g2o crashes if CMAKE_BUILD_TYPE is Release, but not for Debug (slow) or RelWithDebInfo (fast)
@@ -25,7 +25,18 @@ find_package(ament_cmake REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(orb_slam3_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+
+# Debugging: set _dump_all_variables to true
+set(_dump_all_variables true)
+if(_dump_all_variables)
+  get_cmake_property(_variable_names VARIABLES)
+  list(SORT _variable_names)
+  foreach(_variable_name ${_variable_names})
+    message(STATUS "${_variable_name}=${${_variable_name}}")
+  endforeach()
+endif()
 
 # Mono driver
 add_executable(orb_slam3_ros_mono
@@ -40,6 +51,7 @@ target_include_directories(orb_slam3_ros_mono
   ${ORB_SLAM3_SOURCE_DIR}/include
   ${ORB_SLAM3_SOURCE_DIR}/include/CameraModels
   ${Sophus_SOURCE_DIR}
+  ${orb_slam3_msgs_INCLUDE_DIRS}
 )
 
 target_link_libraries(orb_slam3_ros_mono
@@ -49,6 +61,7 @@ target_link_libraries(orb_slam3_ros_mono
   rclcpp::rclcpp
   sensor_msgs::sensor_msgs_library
   ORB_SLAM3
+  ${orb_slam3_msgs_LIBRARIES}
 )
 
 # Mono IMU driver

--- a/orb_slam3_ros/package.xml
+++ b/orb_slam3_ros/package.xml
@@ -3,14 +3,15 @@
 <package format="3">
   <name>orb_slam3_ros</name>
   <version>0.1.0</version>
-  <description>Mono ROS2 ORB_SLAM3 driver</description>
-  <maintainer email="clyde@mcqueen.net">clyde</maintainer>
+  <description>ROS2 ORB_SLAM3 driver</description>
+  <maintainer email="clyde@mcqueen.net">Clyde McQueen</maintainer>
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>eigen</depend>
   <depend>cv_bridge</depend>
+  <depend>orb_slam3_msgs</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
 

--- a/orb_slam3_ros/src/mono.cpp
+++ b/orb_slam3_ros/src/mono.cpp
@@ -1,5 +1,6 @@
 #include "cv_bridge/cv_bridge.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
+#include "orb_slam3_msgs/msg/slam_status.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/image.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
@@ -19,6 +20,7 @@ class MonoNode final : public rclcpp::Node
     rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr image_sub_;
 
     // Declare publications
+    rclcpp::Publisher<orb_slam3_msgs::msg::SlamStatus>::SharedPtr status_pub_;
     rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr cam_pub_;
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr map_pub_;
 
@@ -29,11 +31,9 @@ class MonoNode final : public rclcpp::Node
         "install/orb_slam3_bringup/share/orb_slam3_bringup/param/euroc_mav.yaml");
     std::string world_frame_id_ = declare_parameter<std::string>("world_frame_id",
         "world");
-    bool show_viewer_ = declare_parameter<bool>("show_viewer",
-        false);
 
     // Start ORB_SLAM3
-    ORB_SLAM3::System slam_{voc_file_, settings_file_, ORB_SLAM3::System::MONOCULAR, show_viewer_};
+    ORB_SLAM3::System slam_{voc_file_, settings_file_, ORB_SLAM3::System::MONOCULAR, false};
 
     // Keep track of the SLAM state
     int tracking_state_{};
@@ -44,6 +44,7 @@ public:
     MonoNode() :
         Node("orb_slam3_mono_node")
     {
+        status_pub_ = create_publisher<orb_slam3_msgs::msg::SlamStatus>("slam_status", 10);
         cam_pub_ = create_publisher<geometry_msgs::msg::PoseStamped>("camera_pose", 10);
         map_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>("map_points", 10);
 
@@ -91,9 +92,30 @@ public:
 
         if (tracking_state == ORB_SLAM3::Tracking::eTrackingState::OK) {
             // Publish results
-            publish_pose(image_msg->header.stamp, t_cam_world);
+            publish_pose(image_msg->header.stamp, t_cam_world);  // TODO always publish?
             publish_map(image_msg->header.stamp);
         }
+
+        // TODO refactor
+
+        orb_slam3_msgs::msg::SlamStatus status_msg;
+        status_msg.header.stamp = image_msg->header.stamp;
+        status_msg.header.frame_id = world_frame_id_;
+
+        status_msg.tracking_state = static_cast<int8_t>(tracking_state);
+        status_msg.map_id = map_id;
+        status_msg.map_changed = map_changed;
+
+        // Invert Tcw to get the pose of the camera in the world frame
+        const auto t_world_cam = t_cam_world.inverse();
+        status_msg.pose = to_msg(t_world_cam);
+
+        // Be sure to send tracked points, smaller
+        const auto tracked_points = slam_.GetTrackedMapPoints();
+        const auto msg = to_msg(image_msg->header.stamp, world_frame_id_, tracked_points);
+        status_msg.tracked_points = msg;
+
+        status_pub_->publish(status_msg);
     }
 
     void publish_pose(const builtin_interfaces::msg::Time stamp, const Sophus::SE3f& t_cam_world) const


### PR DESCRIPTION
Consumers need synchronized SLAM outputs. It is possible but complex to handle this on the consumer side. This PR adds the orb_slam3_msgs package with the composite SlamStatus message. This message contains:

* SLAM status
* map_id
* pose
* tracked points

This PR also modifies the mono node:

* publish SlamStatus for every frame
* publish pose and the entire map for every frame (vs only when the status is eTrackingState::OK)

A future PR will add this to the mono_imu node.